### PR TITLE
Allow 16 digit precision

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -299,7 +299,7 @@ static int json_cfg_encode_number_precision(lua_State *l)
 {
     json_config_t *cfg = json_arg_init(l, 1);
 
-    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 14);
+    return json_integer_option(l, 1, &cfg->encode_number_precision, 1, 16);
 }
 
 /* Configures how to treat empty table when encode lua table */

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -50,3 +50,16 @@ print(cjson.encode(b))
 --- out
 ["a=1&b=2"]
 
+=== Test 5: default and max precision
+--- lua
+local math = require "math"
+local cjson = require "cjson"
+local double = math.pow(2, 53)
+print(cjson.encode(double))
+cjson.encode_number_precision(16)
+print(cjson.encode(double))
+print(string.format("%16.0f", cjson.decode("9007199254740992")))
+--- out
+9.007199254741e+15
+9007199254740992
+9007199254740992


### PR DESCRIPTION
Change maximum allowable precision for encode_number_precision from 14 to 16. 

I am experiencing a bug in my application where some client generated sequence numbers are being stored incorrectly due to a loss of precision. As far as I understand, a double has a maximum of 16 decimal places. This module only allows 14. 

```
2015/11/01 01:39:37 [error] 10742#0: *21 lua entry thread aborted: runtime error: ./lib/wiola.lua:10: bad argument #1 to 'encode_number_precision' (expected integer between 1 and 14) 
```