### PR TITLE
fix 16 decimal number encoding assertion

### DIFF
--- a/fpconv.c
+++ b/fpconv.c
@@ -154,7 +154,7 @@ static void set_number_format(char *fmt, int precision)
 {
     int d1, d2, i;
 
-    assert(1 <= precision && precision <= 14);
+    assert(1 <= precision && precision <= 16);
 
     /* Create printf format (%.14g) from precision */
     d1 = precision / 10;


### PR DESCRIPTION
rather minor, but not sure how this made its way in without being noticed, maybe assertions were disabled when developing #4 and the test case was never run separately? Noticed this while running the test suite, it might help to not confuse future contributors.

before:
```
tests/agentzh.t .. 1/10 Failed to execute --- lua for test TEST 5: default and max precision: Assertion failed: (1 <= precision && precision <= 14), function set_number_format, file fpconv.c, line 157.

# Looks like you planned 10 tests but ran 8.
# Looks like your test exited with 25 just after 8.
tests/agentzh.t .. Dubious, test returned 25 (wstat 6400, 0x1900)
Failed 2/10 subtests

Test Summary Report
-------------------
tests/agentzh.t (Wstat: 6400 Tests: 8 Failed: 0)
  Non-zero exit status: 25
  Parse errors: Bad plan.  You planned 10 tests but ran 8.
Files=1, Tests=8,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.06 cusr  0.02 csys =  0.11 CPU)
Result: FAIL
```

now:
```
tests/agentzh.t .. ok
All tests successful.
Files=1, Tests=10,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.06 cusr  0.02 csys =  0.11 CPU)
Result: PASS
```