### PR TITLE
feat: another attempt at cjson.as_array metatable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,124 @@
+Name
+====
+
+lua-cjson - Fast JSON encoding/parsing
+
+Table of Contents
+=================
+
+* [Name](#name)
+* [Description](#description)
+* [Additions to mpx/lua](#additions)
+    * [encode_empty_table_as_object](#encode_empty_table_as_object)
+    * [empty_array](#empty_array)
+    * [empty_array_mt](#empty_array_mt)
+    * [encode_number_precision](#encode_number_precision)
+
+Description
+===========
+
+This fork of [mpx/lua-cjson](https://github.com/mpx/lua-cjson) is included in
+the [OpenResty](https://openresty.org/) bundle and includes a few bugfixes and
+improvements, especially to facilitate the encoding of empty tables as JSON Arrays.
+
+Please refer to the [lua-cjson documentation](http://www.kyne.com.au/~mark/software/lua-cjson.php)
+for standard usage, this README only provides informations regarding this fork's additions.
+
+See [`mpx/master..openresty/master`](https://github.com/mpx/lua-cjson/compare/master...openresty:master)
+for the complete history of changes.
+
+[Back to TOC](#table-of-contents)
+
+Additions
+=========
+
+encode_empty_table_as_object
+----------------------------
+**syntax:** `cjson.encode_empty_table_as_object(true|false|"on"|"off")`
+
+Change the default behavior when encoding an empty Lua table.
+
+By default, empty Lua tables are encoded as empty JSON Objects (`{}`). If this is set to false,
+empty Lua tables will be encoded as empty JSON Arrays instead (`[]`).
+
+This method either accepts a boolean or a string (`"on"`, `"off"`).
+
+[Back to TOC](#table-of-contents)
+
+empty_array
+-----------
+**syntax:** `cjson.empty_array`
+
+A lightuserdata, similar to `cjson.null`, which will be encoded as an empty JSON Array by
+`cjson.encode()`.
+
+For example, since `encode_empty_table_as_object` is `true` by default:
+
+```lua
+local cjson = require "cjson"
+
+local json = cjson.encode({
+    foo = "bar",
+    some_object = {},
+    some_array = cjson.empty_array
+})
+```
+
+This will generate:
+
+```json
+{
+    "foo": "bar",
+    "some_object": {},
+    "some_array": []
+}
+```
+
+[Back to TOC](#table-of-contents)
+
+empty_array_mt
+--------------
+**syntax:** `setmetatable({}, cjson.empty_array_mt)`
+
+A metatable which can "tag" a table as a JSON Array in case it is empty (that is, if the
+table has no elements, `cjson.encode()` will encode it as an empty JSON Array).
+
+Instead of:
+
+```lua
+local function serialize(arr)
+    if #arr < 1 then
+        arr = cjson.empty_array
+    end
+
+    return cjson.encode({some_array = arr})
+end
+```
+
+This is more concise:
+
+```lua
+local function serialize(arr)
+    setmetatable(arr, cjson.empty_array_mt)
+
+    return cjson.encode({some_array = arr})
+end
+```
+
+Both will generate:
+
+```json
+{
+    "some_array": []
+}
+```
+
+[Back to TOC](#table-of-contents)
+
+encode_number_precision
+-----------------------
+**syntax:** `cjson.encode_number_precision(precision)`
+
+This fork allows encoding of numbers with a `precision` up to 16 decimals (vs. 14 in mpx/lua-cjson).
+
+[Back to TOC](#table-of-contents)

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -41,7 +41,79 @@ print(cjson.encode({dogs = {}}))
 
 
 
-=== TEST 4: & in JSON
+=== TEST 4: empty_array userdata
+--- lua
+local cjson = require "cjson"
+print(cjson.encode({arr = cjson.empty_array}))
+--- out
+{"arr":[]}
+
+
+
+=== TEST 5: empty_array_mt
+--- lua
+local cjson = require "cjson"
+local empty_arr = setmetatable({}, cjson.empty_array_mt)
+print(cjson.encode({arr = empty_arr}))
+--- out
+{"arr":[]}
+
+
+
+=== TEST 6: empty_array_mt and empty tables as objects (explicit)
+--- lua
+local cjson = require "cjson"
+local empty_arr = setmetatable({}, cjson.empty_array_mt)
+print(cjson.encode({obj = {}, arr = empty_arr}))
+--- out
+{"arr":[],"obj":{}}
+
+
+
+=== TEST 7: empty_array_mt and empty tables as objects (explicit)
+--- lua
+local cjson = require "cjson"
+cjson.encode_empty_table_as_object(true)
+local empty_arr = setmetatable({}, cjson.empty_array_mt)
+local data = {
+  arr = empty_arr,
+  foo = {
+    obj = {},
+    foobar = {
+      arr = cjson.empty_array,
+      obj = {}
+    }
+  }
+}
+print(cjson.encode(data))
+--- out
+{"foo":{"foobar":{"obj":{},"arr":[]},"obj":{}},"arr":[]}
+
+
+
+=== TEST 8: empty_array_mt on non-empty tables
+--- lua
+local cjson = require "cjson"
+cjson.encode_empty_table_as_object(true)
+local array = {"hello", "world", "lua"}
+setmetatable(array, cjson.empty_array_mt)
+local data = {
+  arr = array,
+  foo = {
+    obj = {},
+    foobar = {
+      arr = cjson.empty_array,
+      obj = {}
+    }
+  }
+}
+print(cjson.encode(data))
+--- out
+{"foo":{"foobar":{"obj":{},"arr":[]},"obj":{}},"arr":["hello","world","lua"]}
+
+
+
+=== TEST 9: & in JSON
 --- lua
 local cjson = require "cjson"
 local a="[\"a=1&b=2\"]"
@@ -52,7 +124,7 @@ print(cjson.encode(b))
 
 
 
-=== TEST 5: default and max precision
+=== TEST 10: default and max precision
 --- lua
 local math = require "math"
 local cjson = require "cjson"


### PR DESCRIPTION
Hey there!

I would really like to see this being pushed forward, so here is my attempt at convincing of the use of such a patch :) Criticism welcome of course. I mean that I will gladly make the necessary changes if something is not appropriate.

First, I would like to point out that the lack of empty table distinction from mpx/lua-cjson has lead to several (if not many) patches trying to solve this. And that I am glad to see this fork already includes the `encode_empty_table_as_object`, but I would like to emphasize on the fact that this feature is not enough even in fairly common use cases.

As an example, let's consider someone using the `log_by_lua_*` phase of ngx_lua (maybe along with `lua-resty-logger-socket`) to serialize the request/response data and send it somewhere to be stored and analyzed later. Such data could have empty objects representing either arrays **or** objects in the **same** Lua table (request headers vs form parameters). This is a simple use case where a higher level of granularity is necessary.

I had to deal with this a few month ago, and the aggregating tool enforced some schema validation, which made it impossible to work around without implementing some very ugly hacks, for which I still do not sleep well at night :)

---

I read the discussion at #1, and while I too believe a lightuserdata would be more efficient and consistent with `cjson.null`, I also think it would offload the actual work to the user.

While the metatable approach is fairly straightforward:
```lua
-- arr and obj might be empty, but never nil
function serialize(arr, obj)
  setmetatable(arr, cjson.as_array)

  local data = {
    foo = arr,
    bar = obj
  }

  return cjson.encode(data)
end
```

The lightuserdata is less:
```lua
function serialize(arr, obj)
  if #arr < 1 then
    arr = cjson.empty_array
  end

  local data = {
    foo = arr,
    bar = obj
  }

  return cjson.encode(data)
end
```

**Note**: if you see a better way of dealing with the userdata approach for users, I would be glad to hear about it and update the patch eventually!

---

Hence, this patch proposes a slightly improved version of #1, taking the given suggestions into account (since the patch was not updated since then):

- more specific name for the metatable key in the Lua registry.
- tests cases moved to t/agentzh.t, where cases for
  'encode_empty_table_as_object' are already written. It seems like a
  better place for tests specific to the OpenResty fork's additions.
- a more complex test case and slightly more concise changes.

Given the number of times such a feature was requested, I believe it would be really great if it could finally be included, if not in mpx/lua-cjson, at least in OpenResty :)