### PR TITLE
fix msvc error

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -75,6 +75,13 @@
 #define DEFAULT_DECODE_INVALID_NUMBERS 0
 #endif
 
+// fix when compile under Microsoft Visual Studio, the compiler will complain that unable to find the reference of strncasecmp
+
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#endif
+
 static const char * const *json_empty_array;
 
 typedef enum {

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -75,7 +75,11 @@
 #define DEFAULT_DECODE_INVALID_NUMBERS 0
 #endif
 
-// fix when compile under Microsoft Visual Studio, the compiler will complain that unable to find the reference of strncasecmp
+/*
+ * 
+ fix when compile under Microsoft Visual Studio, the compiler will complain that unable to find the reference of strncasecmp
+*/
+
 
 #ifdef _MSC_VER
 #define strncasecmp _strnicmp

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -75,11 +75,9 @@
 #define DEFAULT_DECODE_INVALID_NUMBERS 0
 #endif
 
-/*
- * 
- fix when compile under Microsoft Visual Studio, the compiler will complain that unable to find the reference of strncasecmp
-*/
-
+/* 
+ * fix when compile under Microsoft Visual Studio, the compiler will complain 
+ * that unable to find the reference of strncasecmp */
 
 #ifdef _MSC_VER
 #define strncasecmp _strnicmp


### PR DESCRIPTION
when compile with Microsoft Visual Studio, the compiler will complain about the missing reference of strncasecmp, this fix will kill it.

