### PR TITLE
support MS C compiler older than VC2012

### DIFF
--- a/fpconv.c
+++ b/fpconv.c
@@ -35,6 +35,12 @@
 
 #include "fpconv.h"
 
+/* Workaround for MSVC */
+#ifdef _MSC_VER
+#define inline __inline
+#define snprintf sprintf_s
+#endif
+
 /* Lua CJSON assumes the locale is the same for all threads within a
  * process and doesn't change after initialisation.
  *

--- a/lua-cjson-2.1devel-1.rockspec
+++ b/lua-cjson-2.1devel-1.rockspec
@@ -47,7 +47,7 @@ build = {
     -- Override default build options (per platform)
     platforms = {
         win32 = { modules = { cjson = { defines = {
-            "DISABLE_INVALID_NUMBERS"
+            "DISABLE_INVALID_NUMBERS", "USE_INTERNAL_ISINF"
         } } } }
     },
     copy_directories = { "tests" }

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -54,6 +54,16 @@
 #define CJSON_VERSION   "2.1devel"
 #endif
 
+#ifdef _MSC_VER
+#define snprintf sprintf_s
+
+#ifndef isnan
+#include <float.h>
+#define isnan(x) _isnan(x)
+#endif
+
+#endif
+
 /* Workaround for Solaris platforms missing isinf() */
 #if !defined(isinf) && (defined(USE_INTERNAL_ISINF) || defined(MISSING_ISINF))
 #define isinf(x) (!isnan(x) && isnan((x) - (x)))

--- a/strbuf.h
+++ b/strbuf.h
@@ -25,6 +25,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+/* Workaround for MSVC */
+#ifdef _MSC_VER
+#define inline __inline
+#endif
+
 /* Size: Total bytes allocated to *buf
  * Length: String length, excluding optional NULL terminator.
  * Increment: Allocation increments when resizing the string buffer.


### PR DESCRIPTION
Now lua-cjson could be built with VC 2010 or even an older MS C compiler.