### PR TITLE
change: conditionally build luaL_setfuncs() function as newer LuaJIT already includes it. fixes #21.

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1342,8 +1342,9 @@ static int json_decode(lua_State *l)
 
 /* ===== INITIALISATION ===== */
 
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 502
-/* Compatibility for Lua 5.1.
+#if !defined(luaL_newlibtable) && \
+        (!defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 502)
+/* Compatibility for Lua 5.1 and older LuaJIT.
  *
  * luaL_setfuncs() is used to create a module table where the functions have
  * json_config_t as their first upvalue. Code borrowed from Lua 5.2 source. */


### PR DESCRIPTION
Note that due to lack of better feature macro, we are using `luaL_newlibtable` which was added as part of the LuaJIT commit that broke this.