### PR TITLE
deprecate the 'empty_array_mt' field in favor of 'array_mt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Table of Contents
     * [encode_empty_table_as_object](#encode_empty_table_as_object)
     * [empty_array](#empty_array)
     * [empty_array_mt](#empty_array_mt)
+    * [array_mt](#array_mt)
     * [encode_number_precision](#encode_number_precision)
 
 Description
@@ -80,6 +81,16 @@ empty_array_mt
 --------------
 **syntax:** `setmetatable({}, cjson.empty_array_mt)`
 
+**NOTE**: Use of this field is *discouraged* as of the `2.1.0.6` release. This
+field is considered *depcrecated*, and has been renamed to
+[array_mt](#array_mt) for expliciteness.
+
+[Back to TOC](#table-of-contents)
+
+array_mt
+--------
+**syntax:** `setmetatable({}, cjson.array_mt)`
+
 A metatable which can "tag" a table as a JSON Array in case it is empty (that is, if the
 table has no elements, `cjson.encode()` will encode it as an empty JSON Array).
 
@@ -99,7 +110,7 @@ This is more concise:
 
 ```lua
 local function serialize(arr)
-    setmetatable(arr, cjson.empty_array_mt)
+    setmetatable(arr, cjson.array_mt)
 
     return cjson.encode({some_array = arr})
 end

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1444,6 +1444,11 @@ static int lua_cjson_new(lua_State *l)
     lua_rawget(l, LUA_REGISTRYINDEX);
     lua_setfield(l, -2, "empty_array_mt");
 
+    /* Set cjson.array_mt */
+    lua_pushlightuserdata(l, &json_empty_array);
+    lua_rawget(l, LUA_REGISTRYINDEX);
+    lua_setfield(l, -2, "array_mt");
+
     /* Set cjson.empty_array */
     lua_pushlightuserdata(l, &json_empty_array);
     lua_setfield(l, -2, "empty_array");

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -113,7 +113,26 @@ print(cjson.encode(data))
 
 
 
-=== TEST 9: multiple calls to lua_cjson_new (1/2)
+=== TEST 9: cjson.array_mt is an alias to cjson.empty_array_mt
+--- lua
+local cjson = require "cjson"
+print(cjson.array_mt == cjson.empty_array_mt)
+--- out
+true
+
+
+
+=== TEST 10: array_mt behaves as empty_array_mt
+--- lua
+local cjson = require "cjson"
+local empty_arr = setmetatable({}, cjson.array_mt)
+print(cjson.encode({obj = {}, arr = empty_arr}))
+--- out
+{"arr":[],"obj":{}}
+
+
+
+=== TEST 11: multiple calls to lua_cjson_new (1/2)
 --- lua
 local cjson = require "cjson"
 package.loaded["cjson"] = nil
@@ -125,7 +144,7 @@ print(cjson.encode(arr))
 
 
 
-=== TEST 10: multiple calls to lua_cjson_new (2/2)
+=== TEST 12: multiple calls to lua_cjson_new (2/2)
 --- lua
 local cjson = require "cjson.safe"
 -- load another cjson instance (not in package.loaded)
@@ -137,7 +156,7 @@ print(cjson.encode(arr))
 
 
 
-=== TEST 11: & in JSON
+=== TEST 13: & in JSON
 --- lua
 local cjson = require "cjson"
 local a="[\"a=1&b=2\"]"
@@ -148,7 +167,7 @@ print(cjson.encode(b))
 
 
 
-=== TEST 12: default and max precision
+=== TEST 14: default and max precision
 --- lua
 local math = require "math"
 local cjson = require "cjson"


### PR DESCRIPTION
As discussed in #2, this deprecates the `cjson.empty_array_mt` field in favor of `cjson.array_mt`. The new field has the same behavior as the previous one, but simply bears a more explicit name.