### PR TITLE
travis-ci: run LuaJIT tests against openresty/luajit2 -b v2.1-agentzh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,27 +12,42 @@ compiler:
 addons:
   apt:
     packages:
-    - luarocks
     - cppcheck
     - valgrind
     - cpanminus
     - libipc-run3-perl
+    - lua5.1
     - lua5.1-dev
-    - libluajit-5.1-dev
 
 cache:
   apt: true
 
 env:
+  global:
+    - JOBS=3
+    - LUAROCKS_VER=2.4.2
   matrix:
-    - LUA_DEV=liblua5.1-dev LUA_INCLUDE_DIR=/usr/include/lua5.1 LUA_CMODULE_DIR=/lib LUALIB=-llua5.1
-    - LUA_DEV=libluajit-5.1-dev LUA_INCLUDE_DIR=/usr/include/luajit-2.0 LUA_CMODULE_DIR=/lib LUALIB=-lluajit-5.1
+      - LUA=1 LUA_DIR=/usr LUA_INCLUDE_DIR=$LUA_DIR/include/lua5.1
+      - LUAJIT=1 LUA_DIR=/usr/local LUA_INCLUDE_DIR=$LUA_DIR/include/luajit-2.1 LUA_SUFFIX=--lua-suffix=jit
 
 install:
+    - if [ -n "$LUAJIT" ]; then git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git; fi
+    - if [ -n "$LUAJIT" ]; then cd ./luajit2; fi
+    - if [ -n "$LUAJIT" ]; then make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1); fi
+    - if [ -n "$LUAJIT" ]; then sudo make install > build.log 2>&1 || (cat build.log && exit 1); fi
+    - if [ -n "$LUAJIT" ]; then cd ..; fi
+    - if [ -n "$LUAJIT" ]; then sudo ln -s $LUA_DIR/bin/luajit $LUA_DIR/bin/lua; fi
     - sudo cpanm --notest Test::Base Test::LongString > build.log 2>&1 || (cat build.log && exit 1)
+    - wget https://luarocks.github.io/luarocks/releases/luarocks-$LUAROCKS_VER.tar.gz
+    - tar -zxf luarocks-$LUAROCKS_VER.tar.gz
+    - cd luarocks-$LUAROCKS_VER
+    - ./configure --with-lua=$LUA_DIR --with-lua-include=$LUA_INCLUDE_DIR $LUA_SUFFIX
+    - make build
+    - sudo make install
+    - cd ..
 
 script:
-  - cppcheck --force --error-exitcode=1 --enable=warning . > build.log 2>&1 || (cat build.log && exit 1)
+  - cppcheck -i ./luajit2 -i --force --error-exitcode=1 --enable=warning . > build.log 2>&1 || (cat build.log && exit 1)
   - sh runtests.sh
   - make
   - prove -Itests tests


### PR DESCRIPTION
This is to allow #26 to run against LuaJIT 2.1, to test the `array_mt` feature with the `table.new` extension.