### PR TITLE
Support Lua 5.2 plus

### DIFF
--- a/lua/cjson/util.lua
+++ b/lua/cjson/util.lua
@@ -2,6 +2,16 @@ local json = require "cjson"
 
 local unpack = unpack or table.unpack
 
+local maxn = table.maxn or function(t)
+    local max = 0
+    for k,v in pairs(t) do
+        if type(k) == "number" and k > max then
+            max = k
+        end
+    end
+    return max
+end
+
 -- Various common routines used by the Lua CJSON package
 --
 -- Mark Pulford <mark@kyne.com.au>
@@ -194,7 +204,7 @@ local function run_test(testname, func, input, should_work, output)
     local result = {}
     local tmp = { pcall(func, unpack(input)) }
     local success = tmp[1]
-    for i = 2, table.maxn(tmp) do
+    for i = 2, maxn(tmp) do
         result[i - 1] = tmp[i]
     end
 

--- a/lua/cjson/util.lua
+++ b/lua/cjson/util.lua
@@ -1,5 +1,7 @@
 local json = require "cjson"
 
+local unpack = unpack or table.unpack
+
 -- Various common routines used by the Lua CJSON package
 --
 -- Mark Pulford <mark@kyne.com.au>

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -36,6 +36,9 @@
  *       difficult to know object/array sizes ahead of time.
  */
 
+
+#define LUA_COMPAT_ALL 1
+
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -38,6 +38,7 @@
 
 
 #define LUA_COMPAT_ALL 1
+#define LUA_COMPAT_5_1 1
 
 #include <assert.h>
 #include <stdint.h>

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -36,10 +36,6 @@
  *       difficult to know object/array sizes ahead of time.
  */
 
-
-#define LUA_COMPAT_ALL 1
-#define LUA_COMPAT_5_1 1
-
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
@@ -103,6 +99,10 @@
 
 #else
 #define json_lightudata_mask(ludata)    (ludata)
+#endif
+
+#if LUA_VERSION_NUM > 501
+#define lua_objlen(L,i)		lua_rawlen(L, (i))
 #endif
 
 static const char * const *json_empty_array;


### PR DESCRIPTION
This is a very simple change to the library to allow it to run on Lua 5.2 and 5.3 without messing around with how it's built.

I know there is another patch for 5.2/5.3 support, but it seems like it's probably never going to get merged at this point since it's also trying to change some implementation details.

This repo currently is `lua-cjson` on LuaRocks.org, and the rockspec lets it install for Lua 5.2 and 5.3, but it's broken if you try to use it. This patch will make the library work when build through Luarocks on newer versions of Lua.

I recommend a version bump after merging.

Regarding tests... see [my next merge request](https://github.com/openresty/lua-cjson/pull/50). 