### PR TITLE
New test suite for all verions of Lua using GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ jobs:
         luaVersion: ["5.1", "5.2", "5.3", "luajit", "luajit-openresty"]
         include:
           - luaVersion: "luajit"
-            luaIncludeDir: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
+            runtestArgs: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
+            runtestEnv: "SKIP_CMAKE=1"
           - luaVersion: "luajit-openresty"
-            luaIncludeDir: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
+            runtestArgs: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
+            runtestEnv: "SKIP_CMAKE=1"
 
     runs-on: ubuntu-latest
 
@@ -27,7 +29,7 @@ jobs:
 
     - name: test
       run: |
-        LUA_DIR=.lua ./runtests.sh PREFIX=.lua ${{ matrix.luaIncludeDir }}
+        LUA_DIR=.lua ${{ matrix.runtestEnv }} ./runtests.sh PREFIX=.lua ${{ matrix.runtestArgs }}
 
     - name: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,21 @@ jobs:
 
     - uses: leafo/gh-actions-luarocks@v2
 
-    - name: test
+    - name: runtests.sh
       run: |
         LUA_DIR=.lua ${{ matrix.runtestEnv }} ./runtests.sh PREFIX=.lua ${{ matrix.runtestArgs }}
+
+    - name: setup prove
+      run: |
+        make PREFIX=.lua ${{ matrix.runtestArgs }}
+        sudo apt-get install valgrind libipc-run3-perl cppcheck cpanminus
+        sudo cpanm --notest Test::Base Test::LongString
+
+    - name: prove
+      run: LUA_BIN=lua prove -Itests tests
+
+    - name: prove (valgrind)
+      run: LUA_BIN=lua TEST_LUA_USE_VALGRIND=1 prove -Itests tests
 
     - name: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ jobs:
 
     - uses: leafo/gh-actions-luarocks@v2
 
+    - name: test
+      run: |
+        ./runtests.sh
+
     - name: build
       run: |
         luarocks make
 
-    - name: test
-      run: |
-        ./runtests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cc: ["gcc", "clang"]
         luaVersion: ["5.1", "5.2", "5.3", "luajit", "luajit-openresty"]
         include:
           - luaVersion: "luajit"
@@ -21,17 +22,24 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - uses: leafo/gh-actions-lua@v3
+    - uses: leafo/gh-actions-lua@master
+      env:
+        CC: ${{ matrix.cc }}
       with:
         luaVersion: ${{ matrix.luaVersion }}
+        luaCompileFlags: CC=${{ matrix.cc }}
 
     - uses: leafo/gh-actions-luarocks@v2
 
     - name: runtests.sh
+      env:
+        CC: ${{ matrix.cc }}
       run: |
         LUA_DIR=.lua ${{ matrix.runtestEnv }} ./runtests.sh PREFIX=.lua ${{ matrix.runtestArgs }}
 
     - name: setup prove
+      env:
+        CC: ${{ matrix.cc }}
       run: |
         make PREFIX=.lua ${{ matrix.runtestArgs }}
         sudo apt-get install -q valgrind libipc-run3-perl cppcheck cpanminus

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        luaVersion: ["5.1", "5.2", "5.3", "luajit", "luajit-openresty"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: leafo/gh-actions-lua@v3
+      with:
+        luaVersion: ${{ matrix.luaVersion }}
+
+    - uses: leafo/gh-actions-luarocks@v2
+
+    - name: build
+      run: |
+        luarocks make
+
+    - name: test
+      run: |
+        ./runtests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: ["5.1", "5.2", "5.3", "luajit", "luajit-openresty"]
+        include:
+          - luaVersion: "luajit"
+            luaIncludeDir: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
+          - luaVersion: "luajit-openresty"
+            luaIncludeDir: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
 
     runs-on: ubuntu-latest
 
@@ -22,7 +27,7 @@ jobs:
 
     - name: test
       run: |
-        LUA_DIR=.lua ./runtests.sh PREFIX=.lua
+        LUA_DIR=.lua ./runtests.sh PREFIX=.lua ${{ matrix.luaIncludeDir }}
 
     - name: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,11 @@ jobs:
     - name: setup prove
       run: |
         make PREFIX=.lua ${{ matrix.runtestArgs }}
-        sudo apt-get install valgrind libipc-run3-perl cppcheck cpanminus
+        sudo apt-get install -q valgrind libipc-run3-perl cppcheck cpanminus
         sudo cpanm --notest Test::Base Test::LongString
+
+    - name: cppcheck
+      run: cppcheck -I .lua/include -i .lua/ -i .install/ --force --error-exitcode=1 --enable=warning .
 
     - name: prove
       run: LUA_BIN=lua prove -Itests tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         sudo cpanm --notest Test::Base Test::LongString
 
     - name: cppcheck
-      run: cppcheck -I .lua/include -i .lua/ -i .install/ --force --error-exitcode=1 --enable=warning .
+      run: cppcheck -i .lua/ -i .install/ -i dtoa.c --force --error-exitcode=1 --enable=warning .
 
     - name: prove
       run: LUA_BIN=lua prove -Itests tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: test
       run: |
-        ./runtests.sh
+        ./runtests.sh PREFIX=.lua
 
     - name: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: test
       run: |
-        ./runtests.sh PREFIX=.lua
+        LUA_DIR=.lua ./runtests.sh PREFIX=.lua
 
     - name: build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT CMAKE_BUILD_TYPE)
         FORCE)
 endif()
 
-find_package(Lua51 REQUIRED)
+find_package(Lua REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 
 if(NOT USE_INTERNAL_FPCONV)

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+set -eo pipefail
 
 PLATFORM="`uname -s`"
 [ "$1" ] && VERSION="$1" || VERSION="2.1devel"
 
-set -e
 
 # Portable "ggrep -A" replacement.
 # Work around Solaris awk record limit of 2559 bytes.

--- a/runtests.sh
+++ b/runtests.sh
@@ -56,14 +56,20 @@ do_tests
 make clean
 rm -rf tests/cjson{,.so}
 
-echo "===== Testing Cmake build ====="
-mkdir build
-cd build
-cmake ..
-make
-cd ..
-cp -r lua/cjson build/cjson.so tests
-do_tests
-rm -rf build tests/cjson{,.so}
+
+if [ -z "$SKIP_CMAKE" ]; then
+    echo "===== Testing Cmake build ====="
+    mkdir build
+    cd build
+    cmake ..
+    make
+    cd ..
+    cp -r lua/cjson build/cjson.so tests
+    do_tests
+    rm -rf build tests/cjson{,.so}
+else
+    echo "===== Skipping Cmake build ====="
+fi
+
 
 # vi:ai et sw=4 ts=4:

--- a/runtests.sh
+++ b/runtests.sh
@@ -39,7 +39,7 @@ then
 Please ensure you do not have the Lua CJSON module installed before
 running these tests.
 EOT
-    exit
+    exit 1
 fi
 cd ..
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -50,7 +50,7 @@ luarocks remove --local lua-cjson
 make clean
 
 echo "===== Testing Makefile build ====="
-make
+make "$@"
 cp -r lua/cjson cjson.so tests
 do_tests
 make clean

--- a/tests/TestLua.pm
+++ b/tests/TestLua.pm
@@ -32,12 +32,13 @@ sub run_test ($) {
     my ($res, $err);
 
     my @cmd;
+    my $lua_bin = $ENV{LUA_BIN} || "luajit";
 
     if ($ENV{TEST_LUA_USE_VALGRIND}) {
         warn "$name\n";
-        @cmd =  ('valgrind', '-q', '--leak-check=full', 'luajit', 'test_case.lua');
+        @cmd =  ('valgrind', '-q', '--leak-check=full', $lua_bin, 'test_case.lua');
     } else {
-        @cmd =  ('luajit', 'test_case.lua');
+        @cmd =  ($lua_bin, 'test_case.lua');
     }
 
     run3 \@cmd, undef, \$res, \$err;

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -66,8 +66,9 @@ print(cjson.encode({arr = empty_arr}))
 === TEST 6: empty_array_mt and empty tables as objects (explicit)
 --- lua
 local cjson = require "cjson"
+local sort_json = require "tests.sort_json"
 local empty_arr = setmetatable({}, cjson.empty_array_mt)
-print(cjson.encode({obj = {}, arr = empty_arr}))
+print(sort_json(cjson.encode({obj = {}, arr = empty_arr})))
 --- out
 {"arr":[],"obj":{}}
 
@@ -76,6 +77,7 @@ print(cjson.encode({obj = {}, arr = empty_arr}))
 === TEST 7: empty_array_mt and empty tables as objects (explicit)
 --- lua
 local cjson = require "cjson"
+local sort_json = require "tests.sort_json"
 cjson.encode_empty_table_as_object(true)
 local empty_arr = setmetatable({}, cjson.empty_array_mt)
 local data = {
@@ -88,15 +90,16 @@ local data = {
     }
   }
 }
-print(cjson.encode(data))
+print(sort_json(cjson.encode(data)))
 --- out
-{"foo":{"foobar":{"obj":{},"arr":[]},"obj":{}},"arr":[]}
+{"arr":[],"foo":{"foobar":{"arr":[],"obj":{}},"obj":{}}}
 
 
 
 === TEST 8: empty_array_mt on non-empty tables
 --- lua
 local cjson = require "cjson"
+local sort_json = require "tests.sort_json"
 cjson.encode_empty_table_as_object(true)
 local array = {"hello", "world", "lua"}
 setmetatable(array, cjson.empty_array_mt)
@@ -110,9 +113,9 @@ local data = {
     }
   }
 }
-print(cjson.encode(data))
+print(sort_json(cjson.encode(data)))
 --- out
-{"foo":{"foobar":{"obj":{},"arr":[]},"obj":{}},"arr":["hello","world","lua"]}
+{"arr":["hello","world","lua"],"foo":{"foobar":{"arr":[],"obj":{}},"obj":{}}}
 
 
 

--- a/tests/sort_json.lua
+++ b/tests/sort_json.lua
@@ -1,0 +1,61 @@
+-- NOTE: This will only work for simple tests. It doesn't parse strings so if
+-- you put any symbols like {?[], inside of a string literal then it will break
+-- The point of this function is to test basic structures, and not test JSON
+-- strings
+
+local function sort_callback(str)
+  local inside = str:sub(2, -2)
+
+  local parts = {}
+  local buffer = ""
+  local pos = 1
+
+  while true do
+    if pos > #inside then
+      break
+    end
+
+    local append
+
+    local parens = inside:match("^%b{}", pos)
+    if parens then
+      pos = pos + #parens
+      append = sort_callback(parens)
+    else
+      local array = inside:match("^%b[]", pos)
+      if array then
+        pos = pos + #array
+        append = array
+      else
+        local front = inside:sub(pos, pos)
+        pos = pos + 1
+
+        if front == "," then
+          table.insert(parts, buffer)
+          buffer = ""
+        else
+          append = front
+        end
+      end
+    end
+
+    if append then
+      buffer = buffer .. append
+    end
+  end
+
+  if buffer ~= "" then
+    table.insert(parts, buffer)
+  end
+
+  table.sort(parts)
+
+  return "{" .. table.concat(parts, ",") .. "}"
+end
+
+local function sort_json(str)
+  return (str:gsub("%b{}", sort_callback))
+end
+
+
+return sort_json

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -293,7 +293,12 @@ local cjson_tests = {
       true, { '["one",null,null,"sparse test"]' } },
     { "Encode sparse array as object",
       json.encode, { { [1] = "one", [5] = "sparse test" } },
-      true, { '{"5":"sparse test","1":"one"}' } },
+      true, {
+          util.one_of{
+              '{"5":"sparse test","1":"one"}',
+              '{"1":"one","5":"sparse test"}'
+          }
+      } },
     { "Encode table with numeric string key as object",
       json.encode, { { ["2"] = "numeric string key test" } },
       true, { '{"2":"numeric string key test"}' } },

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -294,7 +294,7 @@ local cjson_tests = {
     { "Encode sparse array as object",
       json.encode, { { [1] = "one", [5] = "sparse test" } },
       true, {
-          util.one_of{
+          util.one_of {
               '{"5":"sparse test","1":"one"}',
               '{"1":"one","5":"sparse test"}'
           }
@@ -363,32 +363,71 @@ local cjson_tests = {
       json.encode_keep_buffer, { true }, true, { true } },
 
     -- Test config API errors
-    -- Function is listed as '?' due to pcall
+    -- Function is listed as '?' due to pcall for older versions of Lua
     { "Set encode_number_precision(0) [throw error]",
       json.encode_number_precision, { 0 },
-      false, { "bad argument #1 to '?' (expected integer between 1 and 16)" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (expected integer between 1 and 16)",
+              "bad argument #1 to 'cjson.encode_number_precision' (expected integer between 1 and 16)"
+          }
+      } },
     { "Set encode_number_precision(\"five\") [throw error]",
       json.encode_number_precision, { "five" },
-      false, { "bad argument #1 to '?' (number expected, got string)" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (number expected, got string)",
+              "bad argument #1 to 'cjson.encode_number_precision' (number expected, got string)"
+          }
+      } },
     { "Set encode_keep_buffer(nil, true) [throw error]",
       json.encode_keep_buffer, { nil, true },
-      false, { "bad argument #2 to '?' (found too many arguments)" } },
+      false, {
+          util.one_of {
+              "bad argument #2 to '?' (found too many arguments)",
+              "bad argument #2 to 'cjson.encode_keep_buffer' (found too many arguments)"
+          }
+      } },
     { "Set encode_max_depth(\"wrong\") [throw error]",
       json.encode_max_depth, { "wrong" },
-      false, { "bad argument #1 to '?' (number expected, got string)" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (number expected, got string)",
+              "bad argument #1 to 'cjson.encode_max_depth' (number expected, got string)"
+          }
+      } },
     { "Set decode_max_depth(0) [throw error]",
       json.decode_max_depth, { "0" },
-      false, { "bad argument #1 to '?' (expected integer between 1 and 2147483647)" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (expected integer between 1 and 2147483647)",
+              "bad argument #1 to 'cjson.decode_max_depth' (expected integer between 1 and 2147483647)"
+          }
+      } },
     { "Set encode_invalid_numbers(-2) [throw error]",
       json.encode_invalid_numbers, { -2 },
-      false, { "bad argument #1 to '?' (invalid option '-2')" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (invalid option '-2')",
+              "bad argument #1 to 'cjson.encode_invalid_numbers' (invalid option '-2')"
+          }
+      } },
     { "Set decode_invalid_numbers(true, false) [throw error]",
       json.decode_invalid_numbers, { true, false },
-      false, { "bad argument #2 to '?' (found too many arguments)" } },
+      false, {
+          util.one_of {
+              "bad argument #2 to '?' (found too many arguments)",
+              "bad argument #2 to 'cjson.decode_invalid_numbers' (found too many arguments)"
+          }
+      } },
     { "Set encode_sparse_array(\"not quite on\") [throw error]",
       json.encode_sparse_array, { "not quite on" },
-      false, { "bad argument #1 to '?' (invalid option 'not quite on')" } },
-
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (invalid option 'not quite on')",
+              "bad argument #1 to 'cjson.encode_sparse_array' (invalid option 'not quite on')"
+          }
+      } },
     { "Reset Lua CJSON configuration", function () json = json.new() end },
     -- Wrap in a function to ensure the table returned by json.new() is used
     { "Check encode_sparse_array()",
@@ -400,7 +439,12 @@ local cjson_tests = {
       true, { "true" } },
     { "Encode (safe) argument validation [throw error]",
       json_safe.encode, { "arg1", "arg2" },
-      false, { "bad argument #1 to '?' (expected 1 argument)" } },
+      false, {
+          util.one_of {
+              "bad argument #1 to '?' (expected 1 argument)",
+              "bad argument #1 to 'cjson.safe.encode' (expected 1 argument)"
+          }
+      } },
     { "Decode (safe) error generation",
       json_safe.decode, { "Oops" },
       true, { nil, "Expected value but found invalid token at character 1" } },


### PR DESCRIPTION
As I was writing #49 I wanted to update the test suite to reflect all versions of Lua. I think GitHub actions is probably the future of all CI on GitHub so I opted to go that direction. Sadly it's currently in beta. That means if this pull request is merged, the tests may not actually run until the OpenResty account gets whitelisted for the beta, or the feature is publicly launched (I think that's going to happen soon).

If you're an owner of the OpenResty org go here (you may get granted access immediately): https://github.com/features/actions/signup/

You can see a build here on my account: https://github.com/leafo/lua-cjson/commit/68e2a4a17026e826a661bb001cb86fce27771dc1/checks

The build matrix tests:
* Lua 5.1, 5.2, 5.3, LuaJIT compiled from luajit.org, LuaJIT compiled from the OpenResty fork
* clang and gcc (like current test)

The following test are run:
* original `runtests.sh`
* new tests added by agentzh using perl (+ run with valgrind)
* cppcheck

I tried to make my changes to the existing test suites as conservative as possible, since I don't know if anyone else is depending on them in other build pipelines. I think the entire setup is a huge mess though, and someone probably needs to maintain all the tests in one place for a future patch.

* Any changes to the test suites are done via environment variables, so they'll run the same by default
* I didn't see a way to make cmake detect luajit, so I disabled the cmake build test in `runtests.sh` for luajit
* Hash tables are unordered in Lua, so I added some helper functions to allow testing output despite ordering so the tests are not dependent on a specific implementation of Lua
* ccpcheck is currently broken in Travis, but it wasn't failing the build: `The command "cppcheck -i ./luajit2 -i --force --error-exitcode=1 --enable=warning . > build.log 2>&1 || (cat build.log && exit 1)" exited with 1.`. I fixed the issue on the github actions build
* This pull request also includes my other patch in #49, so that should be merged first