### PR TITLE
Add decode option to ignore JSON null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
     * [empty_array_mt](#empty_array_mt)
     * [encode_number_precision](#encode_number_precision)
     * [decode_array_with_array_mt](#decode_array_with_array_mt)
+    * [decode_json_null](#decode_json_null)
 
 Description
 ===========
@@ -191,5 +192,15 @@ local my_json = [[{"my_array":[]}]]
 local t = cjson.decode(my_json)
 cjson.encode(t) -- {"my_array":[]} properly re-encoded as an array
 ```
+
+[Back to TOC](#table-of-contents)
+
+decode_json_null
+-----------------------
+**syntax:** `cjson.decode_json_null(enabled)`
+
+**default:** true
+
+If disabled, JSON null values will be decoded to Lua `nil` (removed from table) instead of the default `cjson.null` lightuserdata value.
 
 [Back to TOC](#table-of-contents)

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -284,3 +284,19 @@ print(string.format("%16.0f", cjson.decode("9007199254740992")))
 9.007199254741e+15
 9007199254740992
 9007199254740992
+
+
+
+=== TEST 21: optional json null
+--- lua
+local cjson = require "cjson"
+local json = [[{"val1":"str","val2":null,"val3":{"val1":null,"val2":"str"}}]]
+print(cjson.encode(cjson.decode(json)))
+cjson.decode_json_null(false)
+print(cjson.encode(cjson.decode(json)))
+cjson.decode_json_null(true)
+print(cjson.encode(cjson.decode(json)))
+--- out
+{"val3":{"val2":"str","val1":null},"val1":"str","val2":null}
+{"val3":{"val2":"str"},"val1":"str"}
+{"val3":{"val2":"str","val1":null},"val1":"str","val2":null}


### PR DESCRIPTION
By default JSON null values are encoded cjson.null lightuserdata. `cjson.decode_json_null(false)` allows disabling this behavior and instead convert JSON null to Lua nil values.