### PR TITLE
Add configuration option to disable forward slash escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Table of Contents
     * [array_mt](#array_mt)
     * [empty_array_mt](#empty_array_mt)
     * [encode_number_precision](#encode_number_precision)
+    * [encode_escape_forward_slash](#encode_escape_forward_slash)
     * [decode_array_with_array_mt](#decode_array_with_array_mt)
 
 Description
@@ -155,6 +156,18 @@ encode_number_precision
 **syntax:** `cjson.encode_number_precision(precision)`
 
 This fork allows encoding of numbers with a `precision` up to 16 decimals (vs. 14 in mpx/lua-cjson).
+
+[Back to TOC](#table-of-contents)
+
+encode_escape_forward_slash
+---------------------------
+**syntax:** `cjson.encode_escape_forward_slash(enabled)`
+
+**default:** true
+
+If enabled, forward slash '/' will be encoded as '\/'.
+
+If disabled, forward slash '/' will be encoded as '/' (no escape is applied).
 
 [Back to TOC](#table-of-contents)
 

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -81,6 +81,7 @@
 #define DEFAULT_ENCODE_NUMBER_PRECISION 14
 #define DEFAULT_ENCODE_EMPTY_TABLE_AS_OBJECT 1
 #define DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT 0
+#define DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH 1
 
 #ifdef DISABLE_INVALID_NUMBERS
 #undef DEFAULT_DECODE_INVALID_NUMBERS
@@ -155,6 +156,7 @@ typedef struct {
     int encode_number_precision;
     int encode_keep_buffer;
     int encode_empty_table_as_object;
+    int encode_escape_forward_slash;
 
     int decode_invalid_numbers;
     int decode_max_depth;
@@ -406,6 +408,20 @@ static int json_cfg_decode_invalid_numbers(lua_State *l)
     return 1;
 }
 
+static int json_cfg_encode_escape_forward_slash(lua_State *l)
+{
+    int            ret;
+    json_config_t *cfg = json_arg_init(l, 1);
+
+    ret = json_enum_option(l, 1, &cfg->encode_escape_forward_slash, NULL, 1);
+    if (cfg->encode_escape_forward_slash) {
+        char2escape['/'] = "\\/";
+    } else {
+        char2escape['/'] = NULL;
+    }
+    return ret;
+}
+
 static int json_destroy_config(lua_State *l)
 {
     json_config_t *cfg;
@@ -442,6 +458,7 @@ static void json_create_config(lua_State *l)
     cfg->encode_number_precision = DEFAULT_ENCODE_NUMBER_PRECISION;
     cfg->encode_empty_table_as_object = DEFAULT_ENCODE_EMPTY_TABLE_AS_OBJECT;
     cfg->decode_array_with_array_mt = DEFAULT_DECODE_ARRAY_WITH_ARRAY_MT;
+    cfg->encode_escape_forward_slash = DEFAULT_ENCODE_ESCAPE_FORWARD_SLASH;
 
 #if DEFAULT_ENCODE_KEEP_BUFFER > 0
     strbuf_init(&cfg->encode_buf, 0);
@@ -1457,6 +1474,7 @@ static int lua_cjson_new(lua_State *l)
         { "encode_keep_buffer", json_cfg_encode_keep_buffer },
         { "encode_invalid_numbers", json_cfg_encode_invalid_numbers },
         { "decode_invalid_numbers", json_cfg_decode_invalid_numbers },
+        { "encode_escape_forward_slash", json_cfg_encode_escape_forward_slash },
         { "new", lua_cjson_new },
         { NULL, NULL }
     };

--- a/tests/agentzh.t
+++ b/tests/agentzh.t
@@ -284,3 +284,22 @@ print(string.format("%16.0f", cjson.decode("9007199254740992")))
 9.007199254741e+15
 9007199254740992
 9007199254740992
+
+
+
+=== TEST 21: / in string
+--- lua
+local cjson = require "cjson"
+local a={test = "http://google.com/google"}
+local b=cjson.encode(a)
+print(b)
+cjson.encode_escape_forward_slash(false)
+local b=cjson.encode(a)
+print(b)
+cjson.encode_escape_forward_slash(true)
+local b=cjson.encode(a)
+print(b)
+--- out
+{"test":"http:\/\/google.com\/google"}
+{"test":"http://google.com/google"}
+{"test":"http:\/\/google.com\/google"}


### PR DESCRIPTION
This PR is based on #59. Thanks @exjesper for the original patch. I just remove the detection from the hot path to make it a little faster when the escape is disabled.