### PR TITLE
bump version to 2.1.0.9

### DIFF
--- a/lua-cjson-2.1.0.9-1.rockspec
+++ b/lua-cjson-2.1.0.9-1.rockspec
@@ -1,9 +1,9 @@
 package = "lua-cjson"
-version = "2.1.0.6-1"
+version = "2.1.0.9-1"
 
 source = {
     url = "git+https://github.com/openresty/lua-cjson",
-    tag = "2.1.0.6",
+    tag = "2.1.0.9",
 }
 
 description = {

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef CJSON_VERSION
-#define CJSON_VERSION   "2.1.0.6"
+#define CJSON_VERSION   "2.1.0.9"
 #endif
 
 #ifdef _MSC_VER

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -93,7 +93,7 @@ local cjson_tests = {
     -- Test API variables
     { "Check module name, version",
       function () return json._NAME, json._VERSION end, { },
-      true, { "cjson", "2.1.0.6" } },
+      true, { "cjson", "2.1.0.9" } },
 
     -- Test decoding simple types
     { "Decode string",


### PR DESCRIPTION
This creates a new version that we can push to Luarocks. Currently the version on Luarocks reports that it works for lua > 5.1 but it doesn't, so it fails to build and install. The changes that make this library work on later versions of lua have already been in master for many months. 

This pull request is just to confirm that pushing a new numbered version won't break any workflows anywhere else for openresty.

Once we have this merged I'm happy to create the tag and take care of pushing the new version to Luarocks.org on this account: https://luarocks.org/modules/openresty