### PR TITLE
bugfix: fixed a possible division by zero bug found by cppcheck.

### DIFF
--- a/strbuf.c
+++ b/strbuf.c
@@ -150,7 +150,7 @@ static int calculate_new_size(strbuf_t *s, int len)
         /* Exponential sizing */
         while (newsize < reqsize)
             newsize *= -s->increment;
-    } else {
+    } else if (s->increment != 0)  {
         /* Linear sizing */
         newsize = ((newsize + s->increment - 1) / s->increment) * s->increment;
     }


### PR DESCRIPTION
strbuf.c:155:49: warning: Either the condition 's->increment<0' is redundant or there is division by zero at line 155. [zerodivcond]
        newsize = ((newsize + s->increment - 1) / s->increment) * s->increment;