### PR TITLE
bugfix: shift signed 32-bit value by 31 bits should be avoid.

### DIFF
--- a/dtoa.c
+++ b/dtoa.c
@@ -2488,7 +2488,7 @@ fpconv_strtod
 	U aadj2, adj, rv, rv0;
 	ULong y, z;
 	BCinfo bc;
-    Bigint *bb1, *bd0;
+	Bigint *bb1, *bd0;
 	Bigint *bb = NULL;
 	Bigint *bd = NULL;
 	Bigint *bs = NULL;

--- a/dtoa.c
+++ b/dtoa.c
@@ -2488,10 +2488,9 @@ fpconv_strtod
 	U aadj2, adj, rv, rv0;
 	ULong y, z;
 	BCinfo bc;
+    Bigint *bb1, *bd0;
 	Bigint *bb = NULL;
-	Bigint *bb1 = NULL;
 	Bigint *bd = NULL;
-	Bigint *bd0 = NULL;
 	Bigint *bs = NULL;
 	Bigint *delta = NULL;
 #ifdef Avoid_Underflow

--- a/dtoa.c
+++ b/dtoa.c
@@ -2488,7 +2488,12 @@ fpconv_strtod
 	U aadj2, adj, rv, rv0;
 	ULong y, z;
 	BCinfo bc;
-	Bigint *bb, *bb1, *bd, *bd0, *bs, *delta;
+	Bigint *bb = NULL;
+	Bigint *bb1 = NULL;
+	Bigint *bd = NULL;
+	Bigint *bd0 = NULL;
+	Bigint *bs = NULL;
+	Bigint *delta = NULL;
 #ifdef Avoid_Underflow
 	ULong Lsb, Lsb1;
 #endif

--- a/dtoa.c
+++ b/dtoa.c
@@ -2451,10 +2451,10 @@ retlow1:
 		if ((j = ((word0(rv) & Exp_mask) >> Exp_shift) - bc->scale) <= 0) {
 			i = 1 - j;
 			if (i <= 31) {
-				if (word1(rv) & (0x1 << i))
+				if (word1(rv) & (0x1U << i))
 					goto odd;
 				}
-			else if (word0(rv) & (0x1 << (i-32)))
+			else if (word0(rv) & (0x1U << (i-32)))
 				goto odd;
 			}
 		else if (word1(rv) & 1) {


### PR DESCRIPTION
[dtoa.c:2453] -> [dtoa.c:2454]: (warning) Shifting signed 32-bit value by 31 bits is undefined behaviour. See condition at line 2453.
[dtoa.c:2846]: (error) Uninitialized variable: bb
[dtoa.c:2847]: (error) Uninitialized variable: bd
[dtoa.c:2848]: (error) Uninitialized variable: bs
[dtoa.c:2850]: (error) Uninitialized variable: delta