### PR TITLE
windows luarocks make doesn't export cjson.safe

### DIFF
--- a/lua-cjson-2.1.0.9-1.rockspec
+++ b/lua-cjson-2.1.0.9-1.rockspec
@@ -34,6 +34,9 @@ build = {
 -- Uncomment the line below on Solaris platforms if required.
 --                "USE_INTERNAL_ISINF"
             }
+        },
+        ["cjson.safe"] = {
+            sources = { "lua_cjson.c", "strbuf.c", "fpconv.c" }
         }
     },
     install = {


### PR DESCRIPTION
This fixes below, (can't get cjson.safe to load) using luarocks make
```
C:\Program Files (x86)\Lua\5.1\lua.exe: .\sandbox.lua:19: module 'cjson.safe' not found:
        no field package.preload['cjson.safe']
        no file '.\cjson\safe.lua'
        no file 'C:\Program Files (x86)\Lua\5.1\lua\cjson\safe.lua'
        no file 'C:\Program Files (x86)\Lua\5.1\lua\cjson\safe\init.lua'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson\safe.lua'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson\safe\init.lua'
        no file 'C:\Program Files (x86)\Lua\5.1\lua\cjson\safe.luac'
        no file '.\cjson\safe.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson\safe.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\loadall.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\cjson\safe.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\loadall.dll'
        no file '.\cjson\safe51.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson\safe51.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\cjson\safe51.dll'
        no file '.\cjson.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\loadall.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\cjson.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\loadall.dll'
        no file '.\cjson51.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\cjson51.dll'
        no file 'C:\Program Files (x86)\Lua\5.1\clibs\cjson51.dll'
stack traceback:
        [C]: in function 'require'
        .\sandbox.lua:19: in main chunk
        [C]: ?
```