### PR TITLE
Add void to functions with no arguments to prevent compiler warning

### DIFF
--- a/fpconv.c
+++ b/fpconv.c
@@ -55,7 +55,7 @@ static char locale_decimal_point = '.';
  * localconv() may not be thread safe (=>crash), and nl_langinfo() is
  * not supported on some platforms. Use sprintf() instead - if the
  * locale does change, at least Lua CJSON won't crash. */
-static void fpconv_update_locale()
+static void fpconv_update_locale(void)
 {
     char buf[8];
 
@@ -202,7 +202,7 @@ int fpconv_g_fmt(char *str, double num, int precision)
     return len;
 }
 
-void fpconv_init()
+void fpconv_init(void)
 {
     fpconv_update_locale();
 }

--- a/fpconv.h
+++ b/fpconv.h
@@ -12,7 +12,7 @@ static inline void fpconv_init()
     /* Do nothing - not required */
 }
 #else
-extern void fpconv_init();
+extern void fpconv_init(void);
 #endif
 
 extern int fpconv_g_fmt(char*, double, int);


### PR DESCRIPTION
Clang 15.0.0 will give the following warning if (void) isn't provided:

warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
