### PR TITLE
CI: upload rockspec to LuaRocks on tag push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,19 +17,22 @@ jobs:
             runtestArgs: "LUA_INCLUDE_DIR=.lua/include/luajit-2.1"
             runtestEnv: "SKIP_CMAKE=1"
 
+    # due to 'luarocks/gh-actions-lua@master' caching,
+    # keep 'runs-on' synced with 'runs-on' from
+    # 'upload' job below
     runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@master
 
-    - uses: leafo/gh-actions-lua@master
+    - uses: luarocks/gh-actions-lua@master
       env:
         CC: ${{ matrix.cc }}
       with:
         luaVersion: ${{ matrix.luaVersion }}
         luaCompileFlags: CC=${{ matrix.cc }}
 
-    - uses: leafo/gh-actions-luarocks@master
+    - uses: luarocks/gh-actions-luarocks@master
 
     - name: runtests.sh
       env:
@@ -59,3 +62,48 @@ jobs:
       run: |
         luarocks make
 
+  upload:
+    name: Upload Rockspec
+
+    # due to 'luarocks/gh-actions-lua@master' caching,
+    # keep 'runs-on' synced with 'runs-on' from
+    # 'test' job above
+    runs-on: ubuntu-24.04
+
+    needs: test
+    if: ${{ github.repository == 'openresty/lua-cjson' && github.ref_type == 'tag' }}
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: luarocks/gh-actions-lua@master
+    - uses: luarocks/gh-actions-luarocks@master
+    
+    - name: Set environment variable to hold the rockspec name to be uploaded
+      run: |
+        rockspec=$(find *.rockspec | head -n1);
+        echo "ROCKSPEC=${rockspec}" >> "${{ github.env }}";
+    
+    - name: Make sure that tags from GitHub and rockspec are equal
+      run: |
+        rockspec_tag=$(lua -e "dofile(arg[0]); io.write(source.tag);" -- "${{ env.ROCKSPEC }}");
+        github_tag="${{ github.ref_name }}";
+
+        if [[ "${rockspec_tag}" != "${github_tag}" ]];
+        then
+          echo -e "\e[31mTag mismatch\e[0m: GitHub tag (\e[33m${github_tag}\e[0m) != rockspec tag (\e[33m${rockspec_tag}\e[0m)";
+          exit 0;
+        fi;
+    
+    - name: Install dependencies
+      run: |
+        sudo apt install -y libssl-dev;
+        luarocks install luasocket;
+        luarocks install luasec;
+
+    - name: Upload to LuaRocks
+      env:
+        UPLOAD_KEY: "${{ secrets.LUAROCKS_APIKEY }}"
+      run: |
+        echo -e "Uploading rockspec: \e[36m${{ env.ROCKSPEC }}\e[0m";
+        
+        luarocks upload "${{ env.ROCKSPEC }}" "--temp-key" "$UPLOAD_KEY";

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         if [[ "${rockspec_tag}" != "${github_tag}" ]];
         then
           echo -e "\e[31mTag mismatch\e[0m: GitHub tag (\e[33m${github_tag}\e[0m) != rockspec tag (\e[33m${rockspec_tag}\e[0m)";
-          exit 0;
+          exit 1;
         fi;
     
     - name: Install dependencies


### PR DESCRIPTION
## Overview

Since [https://github.com/openresty/lua-cjson](https://github.com/openresty/lua-cjson) has become such a core dependency to a huge amount of packages on LuaRocks, this PR adds a new job to the current CI to upload the rockspec to LuaRocks once a new tag is pushed to GitHub.

## Description

* Added a ```upload``` job to CI, which uploads the rockspec to LuaRocks once a new tag is pushed to GitHub;

> [!NOTE]
> 
> There is a guard to make sure that the GitHub tag matches the rockspec tag (field ```source.tag```), failing the upload job otherwise.

* Once a new tag is pushed, this PR partially fixes [https://github.com/openresty/lua-cjson/issues/96](https://github.com/openresty/lua-cjson/issues/96) and [https://github.com/openresty/lua-cjson/issues/102](https://github.com/openresty/lua-cjson/issues/102) regarding the published rockspecs on LuaRocks;

* Replaced the GitHub actions ```leafo/gh-actions-lua@master``` and ```leafo/gh-actions-luarocks@master``` with ```luarocks/gh-actions-lua@master``` and ```luarocks/gh-actions-luarocks@master``` respectively, due to the former failing to install LuaJIT. See [https://github.com/leafo/gh-actions-lua/issues/49](https://github.com/leafo/gh-actions-lua/issues/49) and [https://github.com/leafo/gh-actions-lua/pull/50](https://github.com/leafo/gh-actions-lua/pull/50).

## Requeriments

In order to upload rockspecs to LuaRocks, a few steps are required:

1. Generate an API key to upload rockspecs to LuaRocks:
    1. Visit [https://luarocks.org/](https://luarocks.org/);
    2. Log in;
    3. Go to ```Settings```;
    4. Generate a new API key and save it to store on a GitHub secret used by the upload job.
2. Generate a GitHub secret to hold LuaRocks API key:
    1. Visit [https://github.com/openresty/lua-cjson](https://github.com/openresty/lua-cjson);
    2. Log in;
    3. Go to ```Settings > Secrets and variables > Actions``` and click ```New repository secret``` button;
    4. Paste ```LUAROCKS_APIKEY``` into Name field, paste LuaRocks API key generated from LuaRocks in the Secret box, and hit ```Add secret``` button.

> [!IMPORTANT]
> 
> The secret name must be ```LUAROCKS_APIKEY```, as is defined in the upload job.

## Workflow Testing

Visit my fork's workflow runs [https://github.com/luau-project/lua-cjson/actions](https://github.com/luau-project/lua-cjson/actions) and check how it ran:

* The run [https://github.com/luau-project/lua-cjson/actions/runs/11882520402](https://github.com/luau-project/lua-cjson/actions/runs/11882520402) happened on a branch ```test-commit```, which had some modifications to allow it reach the upload job (*and avoiding the final upload to LuaRocks*). That run was triggered by a ```git push```;

* The run [https://github.com/luau-project/lua-cjson/actions/runs/11882535036](https://github.com/luau-project/lua-cjson/actions/runs/11882535036) happened on the same branch ```test-commit```, but this time triggered by annotating a tag ```git tag -a "2.1.0.14" -m "Release v2.1.0.14"``` and pushing it to the remote repo ```git push origin 2.1.0.14```.