### PR TITLE
Fixed: worning for explicit pointer to int conversion

### DIFF
--- a/strbuf.c
+++ b/strbuf.c
@@ -164,7 +164,7 @@ void strbuf_resize(strbuf_t *s, size_t len)
     newsize = calculate_new_size(s, len);
 
     if (s->debug > 1) {
-        fprintf(stderr, "strbuf(%) resize: %zd => %zd\n",
+        fprintf(stderr, "strbuf(%p) resize: %zd => %zd\n",
                 s, s->size, newsize);
     }
 

--- a/strbuf.c
+++ b/strbuf.c
@@ -85,8 +85,8 @@ strbuf_t *strbuf_new(size_t len)
 static inline void debug_stats(strbuf_t *s)
 {
     if (s->debug) {
-        fprintf(stderr, "strbuf(%lx) reallocs: %d, length: %zd, size: %zd\n",
-                (long)s, s->reallocs, s->length, s->size);
+        fprintf(stderr, "strbuf(%p) reallocs: %d, length: %zd, size: %zd\n",
+                s, s->reallocs, s->length, s->size);
     }
 }
 
@@ -164,8 +164,8 @@ void strbuf_resize(strbuf_t *s, size_t len)
     newsize = calculate_new_size(s, len);
 
     if (s->debug > 1) {
-        fprintf(stderr, "strbuf(%lx) resize: %zd => %zd\n",
-                (long)s, s->size, newsize);
+        fprintf(stderr, "strbuf(%) resize: %zd => %zd\n",
+                s, s->size, newsize);
     }
 
     s->size = newsize;


### PR DESCRIPTION
```
Process terminated with status 0 (0 minute(s), 4 second(s))
0 error(s), 0 warning(s) (0 minute(s), 4 second(s))
```