### PR TITLE
bugfix: fix truncation of decoded numbers outside lua_Integer's range

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -1190,7 +1190,7 @@ static int json_is_invalid_number(json_parse_t *json)
 static void json_next_number_token(json_parse_t *json, json_token_t *token)
 {
     char *endptr;
-    token->value.integer = strtoll(json->ptr, &endptr, 10);
+    long long tmpval = strtoll(json->ptr, &endptr, 10);
     if (json->ptr == endptr || *endptr == '.' || *endptr == 'e' ||
         *endptr == 'E' || *endptr == 'x') {
         token->type = T_NUMBER;
@@ -1199,8 +1199,16 @@ static void json_next_number_token(json_parse_t *json, json_token_t *token)
             json_set_token_error(token, json, "invalid number");
             return;
         }
+    } else if (tmpval > PTRDIFF_MAX || tmpval < PTRDIFF_MIN) {
+        /* Typical Lua builds typedef ptrdiff_t to lua_Integer. If tmpval is
+         * outside the range of that type, we need to use T_NUMBER to avoid
+         * truncation.
+         */
+        token->type = T_NUMBER;
+        token->value.number = tmpval;
     } else {
         token->type = T_INTEGER;
+        token->value.integer = tmpval;
     }
     json->ptr = endptr;     /* Skip the processed number */
 


### PR DESCRIPTION
json_next_number_token stores the `long long` return value from `stroll`
in a `lua_Integer` (which is typically a typedef for `ptrdiff_t`).

On 32-bit platforms, this ends up storing an 8-byte number into a 4-byte
variable, truncating the value.

Instead, store the converted value in a temporary `long long` variable
so we can detect the scenario and decode into a `lua_Number`.

Signed-off-by: James McCoy <jamessan@jamessan.com>
