### PR TITLE
lua-cjson compatibility with Lua 5.5

### DIFF
--- a/lua/cjson/util.lua
+++ b/lua/cjson/util.lua
@@ -226,7 +226,18 @@ local function run_test(testname, func, input, should_work, output)
     end
 
     local result = {}
-    local tmp = { pcall(func, unpack(input)) }
+    -----------------------------------------------------------
+    -- works with Lua 5.4.x and 5.5.0
+    -- See also https://groups.google.com/g/lua-l/c/9CK0KhdeJRY
+    local input_len = 0
+    for k in pairs(input) do
+       if type(k) == "number" and k > input_len then input_len = k end
+    end
+    local tmp = { pcall(func, unpack(input, 1, input_len)) }
+    -----------------------------------------------------------
+    -- does not work with Lua 5.5.0
+    -- local tmp = { pcall(func, unpack(input)) }
+    -----------------------------------------------------------
     local success = tmp[1]
     for i = 2, maxn(tmp) do
         result[i - 1] = tmp[i]

--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -114,7 +114,9 @@
 #endif
 
 #if LUA_VERSION_NUM >= 502
+#ifndef lua_objlen
 #define lua_objlen(L,i)		luaL_len(L, (i))
+#endif
 #endif
 
 static const char * const *json_empty_array;

--- a/tests/bench.lua
+++ b/tests/bench.lua
@@ -68,7 +68,8 @@ function benchmark(tests, seconds, rep)
     end
 
     local test_results = {}
-    for name, func in pairs(tests) do
+    for k, v in pairs(tests) do
+        local name, func = k, v
         -- k(number), v(string)
         -- k(string), v(function)
         -- k(number), v(function)


### PR DESCRIPTION
**Key changes:**
- `util.lua`: Fixed a failure in negative test case `encode_keep_buffer(nil, true)`. In Lua 5.5, the length operator (#) returns 0 for tables with a nil first element (e.g., { nil, true }), causing unpack() to pass zero arguments to the C function. Replaced implicit unpacking with an explicit length calculation using `pairs()` and `table.unpack(t, 1, len)` to ensure all arguments are correctly passed. See also discussion on Lua mailing list https://groups.google.com/g/lua-l/c/9CK0KhdeJRY.

- `lua_cjson.c`: Resolved a compiler warning (C4005) regarding the redefinition of the 'lua_objlen' macro. Added an #ifndef check to respect the compatibility macro already provided by Lua 5.5 in `luaconf.h`.

- `tests/bench.lua`: Updated benchmarking utility to ensure compatibility with Lua 5.5 environment changes.

These changes ensure that all 128 tests pass successfully on Lua 5.5 and fix issue https://github.com/openresty/lua-cjson/issues/120.