### PR TITLE
fix: avoid NULL deref in cjson.encode_indent() with no args / nil

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -433,7 +433,7 @@ static int json_cfg_encode_indent(lua_State *l)
 
     json_string_option(l, 1, &cfg->encode_indent);
     /* simplify further checking */
-    if (cfg->encode_indent[0] == '\0') cfg->encode_indent = NULL;
+    if (cfg->encode_indent && cfg->encode_indent[0] == '\0') cfg->encode_indent = NULL;
 
     return 1;
 }


### PR DESCRIPTION
## Summary
Calling `cjson.encode_indent()` or `cjson.encode_indent(nil)` crashes with SIGSEGV.

Root cause: `DEFAULT_ENCODE_INDENT` is `NULL` (lua_cjson.c:95). `json_string_option` skips assignment when the argument is nil, so `cfg->encode_indent` stays NULL, and the subsequent `cfg->encode_indent[0] == '\0'` check at line 436 dereferences NULL.

Fix: NULL-check before reading the first byte.

## Repro
```lua
local cjson = require "cjson"
cjson.encode_indent()      -- crashes
cjson.encode_indent(nil)   -- crashes
```

## Test plan
- [ ] `cjson.encode_indent()` no longer crashes; returns current indent setting.
- [ ] `cjson.encode_indent(nil)` same as above.
- [ ] `cjson.encode_indent("  ")` still works.